### PR TITLE
Fix negative word search query

### DIFF
--- a/__tests__/query.unit.test.js
+++ b/__tests__/query.unit.test.js
@@ -510,22 +510,22 @@ describe('test parseQuery with freeSearch', () => {
                             "$and": [
                                 {
                                     "biography": {
-                                        "$regex": /^((?!\btwo\b).)*/gi
+                                        "$regex": /^((?!\btwo\b).)*$/gi
                                     }
                                 },
                                 {
                                     "narrative": {
-                                        "$regex": /^((?!\btwo\b).)*/gi
+                                        "$regex": /^((?!\btwo\b).)*$/gi
                                     }
                                 },
                                 {
                                     "tours": {
-                                        "$regex": /^((?!\btwo\b).)*/gi
+                                        "$regex": /^((?!\btwo\b).)*$/gi
                                     }
                                 },
                                 {
                                     "notes": {
-                                        "$regex": /^((?!\btwo\b).)*/gi
+                                        "$regex": /^((?!\btwo\b).)*$/gi
                                     }
                                 }
                             ]

--- a/query.js
+++ b/query.js
@@ -270,7 +270,7 @@ var searchMap = {
                 + escapeRegExp(term.value)
                 + (term.end ? '\\b' : '');
             if (term.negative === true) { // Does not contain. See https://stackoverflow.com/a/33971012
-                regexpValue = `^((?!${regexpValue}).)*`;
+                regexpValue = `^((?!${regexpValue}).)*$`;
             }
             return {
                 [section.key]: {


### PR DESCRIPTION
Fixes #58  - entering "slave" and not "persian" should now give us only 2 results.

![image](https://user-images.githubusercontent.com/1689183/55825478-f0178180-5aba-11e9-98bb-7ed366af2505.png)

However, note that because of the way this works, entering "slave" and not "persia" will end up giving us results for "persian slave". This is because it matches "persian slave" since it does not contain the whole _word_ Persia. This is expected behavior.