### PR TITLE
Fix date search pills display for only month and with month & year

### DIFF
--- a/public/components/pills/pills.js
+++ b/public/components/pills/pills.js
@@ -44,52 +44,37 @@ export default function() {
 
 
             /*
-            *   Returns a Travel pill.
+             * Generic date pill.
             */
 
-            getPill.travel = function(key, query) {
+            let datePill = dimension => (key, query) => {
 
                 var travelQuery = query[key]
                 var pill = {}
-                pill.dimension = 'travel '
-                pill.value = ''
+                pill.value = '';
+                pill.dimension = dimension;
 
-                if (travelQuery.place) {
-
-                    if (travelQuery.date) {
-                        pill.dimension += 'place and '
-                        pill.value += (travelQuery.place + ', ')
-                    } else {
-                        pill.dimension += 'place'
-                        pill.value += travelQuery.place
-                    }
+                if (travelQuery) {
+    
+                    if (travelQuery.startYear) pill.value += 'from '
+    
+                    if (travelQuery.startYear) pill.value += travelQuery.startYear
+                    if (travelQuery.startMonth) pill.value += (travelQuery.startYear ? '/': '') + travelQuery.startMonth
+                    
+                    if (travelQuery.endYear || travelQuery.endMonth) pill.value += ' until '
+                    
+                    if (travelQuery.endYear) pill.value += travelQuery.endYear
+                    if (travelQuery.endMonth) pill.value += (travelQuery.endYear ? '/': '') + travelQuery.endMonth
 
                 }
 
-                if (travelQuery.date) {
+                return pill;
 
-                    pill.dimension += 'date'
-    
-                    if (travelQuery.date.queryType === 'range') {
-                        pill.dimension += ' range'
-                        if (travelQuery.date.startYear) pill.value += 'from '
-                    }
-    
-                    if (travelQuery.date.startYear) pill.value += travelQuery.date.startYear
-                    if (travelQuery.date.startMonth) pill.value += '/' + travelQuery.date.startMonth
-                    if (travelQuery.date.startDay)  pill.value += '/' + travelQuery.date.startDay
-    
-                    if (travelQuery.date.queryType === 'range') {
-                        if (travelQuery.date.endYear) pill.value += ' until ' + travelQuery.date.endYear
-                        if (travelQuery.date.endMonth) pill.value += '/' + travelQuery.date.endMonth
-                        if (travelQuery.date.endDay) pill.value += '/' + travelQuery.date.endDay
-                    }
-
-                }
-
-                return pill
-
-            } 
+            }
+            
+            getPill.birthDate = datePill("birth date");
+            getPill.deathDate = datePill("death date");
+            getPill.travelDate = datePill("travel date");
 
 
             /*

--- a/public/components/pills/pills.pug
+++ b/public/components/pills/pills.pug
@@ -1,16 +1,12 @@
 p
     .pill(ng-repeat="pill in pills") 
         .pill-dimension {{ pill.dimension }}
-        .pill-value(ng-if="pill.value && pill.value.startYear && pill.value.startYear == pill.value.endYear")
-          strong {{ pill.value.startYear }}
-        .pill-value(ng-if="pill.value && pill.value.startYear && pill.value.startYear != pill.value.endYear")
-          strong {{ pill.value.startYear }} - {{ pill.value.endYear }}
         .pill-value(ng-if="pill.value.uniques")
           span(ng-show="pill.value.uniques | isArray" ng-repeat="value in pill.value.uniques track by $index")
             span(ng-show="$index > 0 && pill.value.operator === 'or' ")  or 
             span(ng-show="$index > 0 && pill.value.operator === 'and' ")  and 
             strong(ng-class="{'pill-negative': value.negative === true}") {{ value._id || value }}
-        .pill-value(ng-if="!pill.value.uniques && !pill.value.startYear")
+        .pill-value(ng-if="!pill.value.uniques")
           strong {{ pill.value }}
         .pill-value.border-left(ng-if="allowRemove")
           a.text-danger(ng-click="removeFromQuery(pill.key)", data-toggle="tooltip", title="Remove")


### PR DESCRIPTION
Date search pills (for birth date, death date, and travel date) now show like this:

![image](https://user-images.githubusercontent.com/1689183/56261375-a23ce380-608f-11e9-9156-93df2ea99205.png)
