### PR TITLE
Mentioned names search

### DIFF
--- a/public/entry/entry.js
+++ b/public/entry/entry.js
@@ -115,7 +115,7 @@ export default ['$scope', '$http', '$stateParams', '$sce', '$timeout', '$locatio
   })
 
   $scope.getMentionedNameSearchUrl = function (name) {
-    let query = { "entry": { "terms": [{ "value": name, "beginning": true, "end": true }], "sections": [{ "key": "biography", "name": "Biography", "checked": true }, { "key": "narrative", "name": "Narrative", "checked": true }, { "key": "tours", "name": "Tours", "checked": true }, { "key": "notes", "name": "Notes", "checked": true }], "operator": "or" } };
+    let query = { "mentionedNames": name };
     return `#/search/${encodeURIComponent(JSON.stringify(query))}`;
   }
 

--- a/public/explore/explore.js
+++ b/public/explore/explore.js
@@ -28,8 +28,9 @@ export default ['$scope', '$http', '$location', '$stateParams', '$state', '$q', 
     { type : 'facet', active : false, label : 'Military careers', field : 'military', suggestions : 'military.rank' },
     { type : 'facet', active : false, label : 'Exhibitions & Awards', subgroup: 'Institution', field : 'exhibitions', suggestions : 'exhibitions.title' },
     { type : 'facet', active : false, label : 'Exhibitions & Awards', subgroup: 'Award type', field : 'exhibitions_activity', suggestions : 'exhibitions.activity' },
-    { type : 'date', active : false, label : 'Travel date', field : 'travelDate'},
-    { type : 'facet', active : false, label : 'Travel place', field : 'travelPlace', suggestions : 'travels.place' },
+    { type : 'facet', active : false, label : 'Mentioned Names', field : 'mentionedNames', suggestions : 'mentionedNames.name' },
+    { type : 'facet', active : false, label : 'Travel Place', field : 'travelPlace', suggestions : 'travels.place' },
+    { type : 'date', active : false, label : 'Travel Date', field : 'travelDate'},
     { type : 'freesearch', active : false, label : 'Free search', field : 'entry' },
   ]
 

--- a/public/search/search.pug
+++ b/public/search/search.pug
@@ -175,6 +175,19 @@
         hr
 
         .form-group
+          label Mentioned Names
+          input.input-sm.form-control(
+            type="text", 
+            ng-model="query.mentionedNames",
+            placeholder="mentioned names ({{ counts.mentionedNames }} entries)",
+            ng-class="{ filled : query.mentionedNames }"
+            typeahead="item for item in getSuggestions('mentionedNames.name', $viewValue)"
+            typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
+            typeahead-on-select="search()")
+
+        hr
+
+        .form-group
           label Travel Place
           input.input-sm.form-control.margin-top(
             type="text", 

--- a/query.js
+++ b/query.js
@@ -284,7 +284,9 @@ var searchMap = {
                 }
             };
         })
-    }))
+    })),
+
+    mentionedNames: (d, exact) => ({ mentionedNames: { $elemMatch: { name: { $regex: getRegExp(d, exact) } } } })
 }
 
 


### PR DESCRIPTION
Fixes #70 
- Add frontend for mentioned names search and explore.
- Search by mentionedNames attribute, not a free text search.
- Make mentioned names link from entries page go to this new search.

![image](https://user-images.githubusercontent.com/1689183/56736712-b337c580-671d-11e9-975a-307714470c93.png)

![image](https://user-images.githubusercontent.com/1689183/56736720-b763e300-671d-11e9-814c-4339bc811bb1.png)
