### PR TITLE
Better dev setup

### DIFF
--- a/Procfile.debug
+++ b/Procfile.debug
@@ -1,2 +1,0 @@
-db: mongod --dbpath data
-web: node --inspect-brk app.js

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 db: mongod --dbpath data
+frontend: webpack --colors --mode=development --watch
 web: node app.js

--- a/README.md
+++ b/README.md
@@ -7,17 +7,16 @@ This is the codebase for the Grand Tour Explorer web project.  To set up a local
   - [MongoDB](https://www.mongodb.com/download-center/v2/community)
 - Clone the repository locally: `git clone https://github.com/cestastanford/grandtour`.
 - From the repository directory, install npm dependencies: `npm install`
-- Create an environmental variable file: `echo "MONGODB_URI='localhost:27017'" > .env`
-- Create and add some secret keys to the environmental variable file.  Keys created via this method aren't suitable for production:
-  - `echo "SECRET_KEY_1='$(date | md5sum | head -c 32)'" >> .env`
-  - `echo "SECRET_KEY_2='$(date | md5sum | head -c 32)'" >> .env`
-  - `echo "SECRET_KEY_3='$(date | md5sum | head -c 32)'" >> .env`
+- Create an environmental variable file called `.env` in the root directory.
 - Add the following to .env:
 ```
+MONGODB_URI=localhost:27017
+SECRET_KEY_1=abc
+SECRET_KEY_2=abc
+SECRET_KEY_3=abc
 SHEETS_EMAIL=...
 SHEETS_PRIVATE_KEY=...
 ```
-- Create a data directory: `mkdir data`
 - Start the server: `npm run dev-start`.  This will create and host a MongoDB database and start the Node server.
 - Check the console output for the automatically-created default admin user login info.  This account is created when no existing user accounts exist.
 - Check the console output for the local address of the site (often http://localhost:5100).  Visit that address and log in!
@@ -31,8 +30,3 @@ To restore a MongoDB database backup into your local database, unzip the backup 
 - In another shell, import the dump: `mongorestore -d test path/to/directory/with/bson`
 - Shut down the MongoDB database (ctrl-C).
 - Start up the development environment, which should automatically create another `default-admin` user: `npm run dev-start`.
-
-
-Debugging
----------
-To debug, run `npm run debug` and then open chrome://inspect in your browser.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "start": "node app.js",
     "heroku-postbuild": "npm test && webpack --mode=production",
-    "dev-start": "concurrently --kill-others \"webpack --colors --mode=development --watch\" \"heroku local -f Procfile.dev\"",
-    "debug": "concurrently --kill-others \"webpack --colors --mode=development --watch\" \"heroku local -f Procfile.debug\"",
+    "dev-start": "heroku local -f Procfile.dev",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
- Run webpack from heroku Procfile.dev for smoother development
- No need to create a `data` directory on first-time setup
- Update README to be clearer about the `.env` file
- Remove `debug` option which was never used