### PR TITLE
Counts accurate on Search page

### DIFF
--- a/public/components/search-field/date-search.pug
+++ b/public/components/search-field/date-search.pug
@@ -7,7 +7,6 @@
         placeholder="year",
         ng-class="{ filled : dateModel.date.query.startYear }",
         ng-show="dateModel.date.queryType === 'exact'")
-<!-- Edited placeholder, perhaps should be "year ({{ counts.travel_year }} entries)" -->
     
     input.input-sm.form-control.margin-top(
         type="text", 
@@ -16,7 +15,6 @@
         placeholder="month",
         ng-class="{ filled : dateModel.date.query.startMonth }",
         ng-show="dateModel.date.queryType === 'exact'")
-<!-- Edited placeholder, perhaps should be "month ({{ counts.travel_month }} entries)" -->    
     
     input.input-sm.form-control.margin-top(
         type="text", 
@@ -24,7 +22,6 @@
         placeholder="start year",
         ng-class="{ filled : dateModel.date.query.startYear }",
         ng-show="dateModel.date.queryType === 'range'")
-<!-- Edited placeholder, perhaps should be "start year ({{ counts.travel_year }} entries)" -->    
     
     input.input-sm.form-control.margin-top(
         type="text", 
@@ -33,7 +30,6 @@
         placeholder="start month",
         ng-class="{ filled : dateModel.date.query.startMonth }",
         ng-show="dateModel.date.queryType === 'range'")
-<!-- Edited placeholder, perhaps should be "start month ({{ counts.travel_month }} entries)" -->    
     
     input.input-sm.form-control.margin-top(
         type="text", 
@@ -41,7 +37,6 @@
         placeholder="end year",
         ng-class="{ filled : dateModel.date.query.endYear }",
         ng-show="dateModel.date.queryType === 'range'")
-<!-- Edited placeholder, perhaps should be "end year ({{ counts.travel_year }} entries)" -->    
     
     input.input-sm.form-control.margin-top(
         type="text", 
@@ -50,8 +45,6 @@
         placeholder="end month",
         ng-class="{ filled : dateModel.date.query.endMonth }",
         ng-show="dateModel.date.queryType === 'range'")
-<!-- Edited placeholder, perhaps should be "end month ({{ counts.travel_month }} entries)" -->    
-
     
     .margin-top
         span.date-query-type.date-query-type-label search by: 

--- a/public/components/search-field/date-search.pug
+++ b/public/components/search-field/date-search.pug
@@ -4,48 +4,54 @@
     input.input-sm.form-control.margin-top(
         type="text", 
         ng-model="dateModel.date.query.startYear",
-        placeholder="year ({{ counts.travel_year }} entries)",
+        placeholder="year",
         ng-class="{ filled : dateModel.date.query.startYear }",
         ng-show="dateModel.date.queryType === 'exact'")
+<!-- Edited placeholder, perhaps should be "year ({{ counts.travel_year }} entries)" -->
     
     input.input-sm.form-control.margin-top(
         type="text", 
         ng-if="hasMonths",
         ng-model="dateModel.date.query.startMonth",
-        placeholder="month ({{ counts.travel_month }} entries)",
+        placeholder="month",
         ng-class="{ filled : dateModel.date.query.startMonth }",
         ng-show="dateModel.date.queryType === 'exact'")
-    
+<!-- Edited placeholder, perhaps should be "month ({{ counts.travel_month }} entries)" -->    
     
     input.input-sm.form-control.margin-top(
         type="text", 
         ng-model="dateModel.date.query.startYear",
-        placeholder="start year ({{ counts.travel_year }} entries)",
+        placeholder="start year",
         ng-class="{ filled : dateModel.date.query.startYear }",
         ng-show="dateModel.date.queryType === 'range'")
+<!-- Edited placeholder, perhaps should be "start year ({{ counts.travel_year }} entries)" -->    
     
     input.input-sm.form-control.margin-top(
         type="text", 
         ng-if="hasMonths",
         ng-model="dateModel.date.query.startMonth",
-        placeholder="start month ({{ counts.travel_month }} entries)",
+        placeholder="start month",
         ng-class="{ filled : dateModel.date.query.startMonth }",
         ng-show="dateModel.date.queryType === 'range'")
+<!-- Edited placeholder, perhaps should be "start month ({{ counts.travel_month }} entries)" -->    
     
     input.input-sm.form-control.margin-top(
         type="text", 
         ng-model="dateModel.date.query.endYear",
-        placeholder="end year ({{ counts.travel_year }} entries)",
+        placeholder="end year",
         ng-class="{ filled : dateModel.date.query.endYear }",
         ng-show="dateModel.date.queryType === 'range'")
+<!-- Edited placeholder, perhaps should be "end year ({{ counts.travel_year }} entries)" -->    
     
     input.input-sm.form-control.margin-top(
         type="text", 
         ng-if="hasMonths",
         ng-model="dateModel.date.query.endMonth",
-        placeholder="end month ({{ counts.travel_month }} entries)",
+        placeholder="end month",
         ng-class="{ filled : dateModel.date.query.endMonth }",
         ng-show="dateModel.date.queryType === 'range'")
+<!-- Edited placeholder, perhaps should be "end month ({{ counts.travel_month }} entries)" -->    
+
     
     .margin-top
         span.date-query-type.date-query-type-label search by: 

--- a/public/components/search-field/free-search.pug
+++ b/public/components/search-field/free-search.pug
@@ -5,7 +5,7 @@
             input.input-field.input-sm.form-control(
                 type="text", 
                 ng-model="term.value",
-                placeholder="text ({{ counts.fullName }} entries)",
+                placeholder="text",
                 ng-class="{ filled: term.value }",
             )
             

--- a/public/entry/entry-highlighting.js
+++ b/public/entry/entry-highlighting.js
@@ -29,7 +29,7 @@ export default function() {
         }
 
         if (savedQuery.travel) {
-            savedQuery.travel_place = savedQuery.travel.place
+            savedQuery.travelPlace = savedQuery.travel.place
         }
 
     }
@@ -66,7 +66,7 @@ export default function() {
         var value = '' + propertyValue
         var queries = null
         
-        if (propertyName === 'travel_place') {
+        if (propertyName === 'travelPlace') {
             value = propertyValue.place
             if (!highlightTravel(propertyValue)) return value
         }

--- a/public/entry/entry.pug
+++ b/public/entry/entry.pug
@@ -335,7 +335,7 @@
                   tbody
                     tr(class="entry-travel" ng-repeat="travel in tour.values" ng-click="searchTravel(travel)" style="cursor: pointer;", ng-mouseenter="miniMapShared.travelHovered(travel)" ng-mouseleave="miniMapShared.travelUnhovered(travel)" ng-class="{'minimap-hovered': travel.hovered}")
                       td(ng-class="{'bordered':travel.parent}")
-                        span(ng-bind-html="highlighted('travel_place', travel)")
+                        span(ng-bind-html="highlighted('travelPlace', travel)")
                       td.text-right.tnum-lnum
                         span(ng-class="{'highlighted': highlightTravel(travel)}")
                           span(ng-show="!travel.travelStartYear") -

--- a/public/search/search.pug
+++ b/public/search/search.pug
@@ -17,7 +17,7 @@
           input.input-sm.form-control(
             type="text", 
             ng-model="query.fullName",
-            placeholder="Search ({{ counts.fullName }} entries)",
+            placeholder="name",
             ng-class="{ filled : query.fullName }"
             typeahead="item.nameMatch as item for item in getSuggestions('fullName', $viewValue)"
             typeahead-template-url="components/fullname-search-suggestion"
@@ -30,7 +30,7 @@
           input.input-sm.form-control.margin-top(
             type="text", 
             ng-model="query.birthPlace",
-            placeholder="place ({{ counts.birthPlace }} entries)",
+            placeholder="place",
             ng-class="{ filled : query.birthPlace }"
             typeahead="item for item in getSuggestions('places.birthPlace', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -42,7 +42,7 @@
           input.input-sm.margin-top.form-control(
             type="text", 
             ng-model="query.deathPlace",
-            placeholder="place ({{ counts.deathPlace }} entries)",
+            placeholder="place",
             ng-class="{ filled : query.deathPlace }"
             typeahead="item for item in getSuggestions('places.deathPlace', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -53,7 +53,7 @@
           input.input-sm.form-control(
             type="text", 
             ng-model="query.pursuits",
-            placeholder="employment or identifier ({{ counts.pursuits }} entries)",
+            placeholder="employment or identifier",
             ng-class="{ filled : query.pursuits }"
             typeahead="item for item in getSuggestions('pursuits.pursuit', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -64,7 +64,7 @@
           input.input-sm.form-control(
             type="text", 
             ng-model="query.occupations",
-            placeholder="occupation ({{ counts.occupations }} entries)",
+            placeholder="occupation",
             ng-class="{ filled : query.occupations }"
             typeahead="item for item in getSuggestions('occupations.title', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -72,7 +72,7 @@
           input.input-sm.form-control.margin-top(
             type="text", 
             ng-model="query.occupations_group",
-            placeholder="group ({{ counts.occupations_group }} entries)",
+            placeholder="group",
             ng-class="{ filled : query.occupations_group }"
             typeahead="item for item in getSuggestions('occupations.group', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -80,7 +80,7 @@
           input.input-sm.form-control.margin-top(
             type="text", 
             ng-model="query.occupations_place",
-            placeholder="place ({{ counts.occupations_place }} entries)",
+            placeholder="place",
             ng-class="{ filled : query.occupations_place }"
             typeahead="item for item in getSuggestions('occupations.place', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -91,7 +91,7 @@
           input.input-sm.form-control(
             type="text", 
             ng-model="query.military",
-            placeholder="rank ({{ counts.military }} entries)",
+            placeholder="rank",
             ng-class="{ filled : query.military }"
             typeahead="item for item in getSuggestions('military.rank', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -103,7 +103,7 @@
           input.input-sm.form-control(
             type="text", 
             ng-model="query.societies",
-            placeholder="society ({{ counts.societies }} entries)",
+            placeholder="society",
             ng-class="{ filled : query.societies }"
             typeahead="item for item in getSuggestions('societies.title', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -111,7 +111,7 @@
           input.input-sm.form-control.margin-top(
             type="text", 
             ng-model="query.societies_role",
-            placeholder="role ({{ counts.societies_role }} entries)",
+            placeholder="role",
             ng-class="{ filled : query.societies_role }"
             typeahead="item for item in getSuggestions('societies.role', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -123,7 +123,7 @@
           input.input-sm.form-control(
             type="text", 
             ng-model="query.exhibitions",
-            placeholder="institution ({{ counts.exhibitions }} entries)",
+            placeholder="institution",
             ng-class="{ filled : query.exhibitions }"
             typeahead="item for item in getSuggestions('exhibitions.title', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -131,7 +131,7 @@
           input.input-sm.form-control.margin-top(
             type="text", 
             ng-model="query.exhibitions_activity",
-            placeholder="activity ({{ counts.exhibitions_activity }} entries)",
+            placeholder="activity",
             ng-class="{ filled : query.exhibitions_activity }"
             typeahead="item for item in getSuggestions('exhibitions.activity', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -142,7 +142,7 @@
           input.input-sm.form-control(
             type="text", 
             ng-model="query.education_institution",
-            placeholder="institution ({{ counts.education_institution }} entries)",
+            placeholder="institution",
             ng-class="{ filled : query.education_institution }"
             typeahead="item for item in getSuggestions('education.institution', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -150,7 +150,7 @@
           input.input-sm.form-control.margin-top(
             type="text", 
             ng-model="query.education_place",
-            placeholder="place ({{ counts.education_place }} entries)",
+            placeholder="place",
             ng-class="{ filled : query.education_place }"
             typeahead="item for item in getSuggestions('education.place', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -158,7 +158,7 @@
           input.input-sm.form-control.margin-top(
             type="text", 
             ng-model="query.education_teacher",
-            placeholder="teacher ({{ counts.education_teacher }} entries)",
+            placeholder="teacher",
             ng-class="{ filled : query.education_teacher }"
             typeahead="item for item in getSuggestions('education.teacher', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -166,7 +166,7 @@
           input.input-sm.form-control.margin-top(
             type="text", 
             ng-model="query.education_degree",
-            placeholder="degree ({{ counts.education_degree }} entries)",
+            placeholder="degree",
             ng-class="{ filled : query.education_degree }"
             typeahead="item for item in getSuggestions('education.fullDegree', $viewValue)"
             typeahead-min-length="2", typeahead-wait-ms="100"
@@ -179,7 +179,7 @@
           input.input-sm.form-control(
             type="text", 
             ng-model="query.mentionedNames",
-            placeholder="mentioned names ({{ counts.mentionedNames }} entries)",
+            placeholder="name",
             ng-class="{ filled : query.mentionedNames }"
             typeahead="item for item in getSuggestions('mentionedNames.name', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -192,7 +192,7 @@
           input.input-sm.form-control(
             type="text", 
             ng-model="query.consolidated_notes",
-            placeholder="footnotes ({{ counts.consolidated_notes }} entries)",
+            placeholder="footnote",
             ng-class="{ filled : query.consolidated_notes }"
             typeahead="item for item in getSuggestions('consolidated_notes', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"
@@ -205,7 +205,7 @@
           input.input-sm.form-control.margin-top(
             type="text", 
             ng-model="query.travelPlace",
-            placeholder="place ({{ counts.travelPlace }} entries)",
+            placeholder="place",
             ng-class="{ filled : query.travelPlace }"
             typeahead="item for item in getSuggestions('places.travelPlace', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"

--- a/public/search/search.pug
+++ b/public/search/search.pug
@@ -42,7 +42,7 @@
           input.input-sm.margin-top.form-control(
             type="text", 
             ng-model="query.deathPlace",
-            placeholder="place ({{ counts.birthPlace }} entries)",
+            placeholder="place ({{ counts.deathPlace }} entries)",
             ng-class="{ filled : query.deathPlace }"
             typeahead="item for item in getSuggestions('places.deathPlace', $viewValue)"
             typeahead-focus-first="false" typeahead-min-length="2", typeahead-wait-ms="100"

--- a/query.js
+++ b/query.js
@@ -20,10 +20,10 @@ exports.getCounts = async revisionIndex => {
 
             fullName: { fullName: { $ne: null, $ne: '' } },
             alternateNames: { 'alternateNames.alternateName': { $exists: true } },
-            birthDate: { 'dates.0.birthDate': { $exists: true } },
-            birthPlace: { 'places.0.birthPlace': { $exists: true } },
-            deathDate: { 'dates.0.deathDate': { $exists: true } },
-            deathPlace: { 'places.0.deathPlace': { $exists: true } },
+            birthDate: { 'dates.birthDate': { $exists: true } },
+            birthPlace: { 'places.birthPlace': { $exists: true } },
+            deathDate: { 'dates.deathDate': { $exists: true } },
+            deathPlace: { 'places.deathPlace': { $exists: true } },
             type: { type: { $ne: null } },
             societies: { 'societies.title': { $exists: true } },
             societies_role: { 'societies.role': { $exists: true } },
@@ -36,14 +36,15 @@ exports.getCounts = async revisionIndex => {
             occupations_group: { 'occupations.group': { $exists: true } },
             occupations_place: { 'occupations.place': { $exists: true } },
             military: { 'military.rank': { $exists: true } },
-            travel_place: { travels: { $not: { $size: 0 } }, 'travels.place': { $exists: true } },
-            travel_date: { travels: { $not: { $size: 0 } }, $or: [{ 'travels.travelStartYear': { $ne: 0 } }, { 'travels.travelEndYear': { $ne: 0 } }] },
+            travelPlace: { travels: { $not: { $size: 0 } }, 'travels.place': { $exists: true } },
+            travelDate: { travels: { $not: { $size: 0 } }, $or: [{ 'travels.travelStartYear': { $ne: 0 } }, { 'travels.travelEndYear': { $ne: 0 } }] },
             travel_year: { travels: { $not: { $size: 0 } }, $or: [{ 'travels.travelStartYear': { $ne: 0 } }, { 'travels.travelEndYear': { $ne: 0 } }] },
             travel_month: { travels: { $not: { $size: 0 } }, $or: [{ 'travels.travelStartMonth': { $ne: 0 } }, { 'travels.travelEndMonth': { $ne: 0 } }] },
             travel_day: { travels: { $not: { $size: 0 } }, $or: [{ 'travels.travelStartDay': { $ne: 0 } }, { 'travels.travelEndDay': { $ne: 0 } }] },
             exhibitions: { 'exhibitions.title': { $exists: true } },
             exhibitions_activity: { 'exhibitions.activity': { $exists: true } },
-
+            mentionedNames: { 'mentionedNames.name': { $exists: true } },
+            consolidated_notes: { 'consolidated_notes': { $exists: true } },
         }
 
         const facets = {}


### PR DESCRIPTION
Fixes #126. Footnotes and Mentioned names' placeholders now have counts displayed.

For the dates, @ceserani and I discussed making the change from (for example) "year (2435 entries)" to just display "year", as we decided it did not make much sense to give the number of entries in the case of dates. I can do the same thing for the Explore page when I update the dot descriptions.

Also, changed travel_date and travel_place to travelDate and travelPlace to be more consistent with how other filters are named. In other variables, the underscores are reserved for sub-sections (like societies_role), and camel case is used for the main filters.