### PR TITLE
fix: hide parents when empty

### DIFF
--- a/public/entry/entry.pug
+++ b/public/entry/entry.pug
@@ -139,7 +139,7 @@
                     ng-bind-html="highlighted('pursuits', e.pursuit)"
                   )
                     
-          .col-lg-12.col-md-4.col-sm-6(ng-show="entry.parents")
+          .col-lg-12.col-md-4.col-sm-6(ng-show="entry.parents && entry.parents.parents")
             .panel.panel-default
               .panel-heading Parents
               ul.list-group


### PR DESCRIPTION
Fixes #92. Now, when going to an entry such as http://localhost:5200/#/entries/23.1 which has a value of `{}` for parents, then it will hide the "Parents" section.