### PR TITLE
Dots Update 2 + website appearance cleanup

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -1015,15 +1015,15 @@ ul.list-group.entry-facet > li .controls {
 div.tool_tip {	
   position: absolute;			
   text-align: center;			
-  width: 100px;					
-  height: 38px;
+  display: inline-block;
   margin-left: 20px;
   margin-bottom: 30px;
-  padding: 2px;				
-  font: 12px sans-serif;		
-  background: lightgray;	
+  padding: 5px;				
+  font: 13px 'Open Sans', sans-serif;		
+  background: white;	
   border: 0px;		
-  border-radius: 8px;			
+  border-radius: 0px;
+  box-shadow: 0 2px 10px #ccc;			
   pointer-events: none;
   text-overflow: ellipsis;		
 }

--- a/public/app.css
+++ b/public/app.css
@@ -883,7 +883,7 @@ ul.list-group.entry-facet > li .controls {
 }
 
 .free-search-input {
-  margin-top: 1em;
+  margin-top: .5em;
   margin-bottom: .5em;
 }
 

--- a/public/components/search-field/date-search.pug
+++ b/public/components/search-field/date-search.pug
@@ -1,5 +1,6 @@
 .form-group
- 
+    label {{title}}
+    
     input.input-sm.form-control.margin-top(
         type="text", 
         ng-model="dateModel.date.query.startYear",

--- a/public/components/search-field/date-search.pug
+++ b/public/components/search-field/date-search.pug
@@ -1,6 +1,5 @@
 .form-group
-    label {{title}}
-    
+ 
     input.input-sm.form-control.margin-top(
         type="text", 
         ng-model="dateModel.date.query.startYear",

--- a/public/explore/explore.pug
+++ b/public/explore/explore.pug
@@ -40,7 +40,7 @@
                           ng-style="{'margin-left': '15px', 'margin-top': '-30px', display: 'block', opacity: tooltip == dimension.field ? '1': '0', 'z-index': tooltip == dimension.field ? 99: -1, clear: both}"
                     )
                         h4(ng-if="dimension.label !== 'DBITI Employments & Identifiers'") {{ dimension.label }}
-                        div(ng-if="dimension.label === 'DBITI Employments & Identifiers'" style="margin-bottom: 10px")
+                        div(ng-if="dimension.label === 'DBITI Employments & Identifiers'" style="margin: 10px 0px")
                           h4(style="font-style: italic; display: inline") DBITI 
                           h4(style="font-style: normal; display: inline") Employments & Identifiers
                         p {{ dimension.description }}

--- a/public/visualization.component.ts
+++ b/public/visualization.component.ts
@@ -1,7 +1,6 @@
 /*
- * Based on designs by Ashwin Ramaswami and Cody Leff. This file handles the "View" feature of the website. The Travelers feature displays entries
- * as dots, allowing one to color, size, and group them according to certain properties. The Map feature will display a map of Italy with
- * locations of tours.
+ * This file handles the "View" feature of the website. The Travelers feature displays entries as dots, allowing one to color, size, and group 
+ * them according to certain properties. The Map feature is handled by mapbox.html.
  */
 
 import d3 from "d3";
@@ -23,7 +22,7 @@ const COLOR_MALE = "#6D808E";
 const COLOR_FEMALE = "#FAB876";
 const COLOR_OLD = "#6D808E";
 const COLOR_NEW = "#AC7BCD";
-const COLOR_OTHER = "black";
+const COLOR_OTHER = "#333";
 const COLOR_QUESTION = "#257DBD";
 
 const SIZE_DEFAULT = 3;
@@ -55,7 +54,7 @@ const SIZE_DEFAULT = 3;
                 <p>SIZE</p>
                 <select id="size" (change)="update()">
                     <option value="none">None</option>
-                    <option value="length">Entry length</option>
+                    <option value="length">Word count</option>
                     <option value="travelTime">Travel length</option>
                 </select>
             </div>
@@ -68,7 +67,7 @@ const SIZE_DEFAULT = 3;
                     <option value="tours">Number of tours</option>
                 </select>
             </div>
-            <p style='font-family: serif; font-size: 11pt; display: inline-block; padding: 0px 8px'>Each dot represents a traveler and all 6005 travelers are represented...</p>
+            <p class="hover-item" style='font-family: serif; font-size: 11pt; display: inline-block; padding: 0px 8px; cursor: pointer'>Each dot represents a traveler and all 6005 travelers are represented...</p>
             <svg width="100%" height="1250px" id="mySvg" (click)="clicked($event)"></svg>
         </div>
     </div>
@@ -80,6 +79,19 @@ const SIZE_DEFAULT = 3;
         border-top: 1px solid #dddddd;
         border-bottom-right-radius: 2px;
         border-bottom-left-radius: 2px;
+    }
+
+    .hover-item:link {
+        color: black;
+        text-decoration: none;
+    }
+
+    .hover-item:hover {
+        color: #d6bc73;
+    }
+
+    .hover-item:active {
+        color: #d0b67d;
     }
     `]
 })
@@ -113,6 +125,7 @@ export class VisualizationComponent {
     }
 
     clear() {
+        d3.selectAll("body > div").remove(); // removes remaining tooltips
         d3.selectAll("svg > *").remove();
     }
 
@@ -128,9 +141,6 @@ export class VisualizationComponent {
         let x = 1;
         let y = groupBy == "none" || colorBy == "none" ? 15 : 30;
 
-        if (colorBy !== "none") {
-            this.drawLegend(colorBy);
-        }
         for (let i in entryGroups) {
             const group = allGroups[i];
             const entriesInGroup = (entryGroups[i] as { entries: any[], request: any }).entries;
@@ -143,6 +153,9 @@ export class VisualizationComponent {
 
             let dotGroup = this.drawDots(entriesInGroup, colorBy, sizeBy, y);
             y = dotGroup + 50;
+        }
+        if (colorBy !== "none") {
+            this.drawLegend(colorBy);
         }
         var svg = document.getElementById("mySvg");
         if (svg) {
@@ -157,14 +170,10 @@ export class VisualizationComponent {
     drawLegend(colorBy) {
         let div = d3.select("body").append("div")
             .attr("class", "tool_tip")
-            .style("border-radius", 0)
-            .style("background-color", "white")
-            .style("box-shadow", "0 2px 10px #ccc")
             .style("opacity", 0)
-            .style("padding", "5px")
-            .style("font-family", "serif")
-            .style("text-size", "10pt")
-            .style("width", "25%");
+            .style("padding", "12px")
+            .style("width", "200px")
+            .style("text-align", "left");
         switch (colorBy) {
             case "gender":
                 d3.select('svg').append('circle')
@@ -202,15 +211,15 @@ export class VisualizationComponent {
                     .attr("y", LEGEND_TEXT_HEIGHT)
                     .attr("font-weight", 700)
                     .attr("fill", COLOR_QUESTION)
+                    .style("cursor", "pointer")
                     .text("?")
                     .on("mouseover", function (d) {
-                        div.style("height", "40px")
+                        div.style("height", "80px")
                         div.transition()
                             .style("opacity", 1);
-                        div.text("Gender is a category we attributed and is not always available...")
+                        div.text("Gender is a category we attributed and is not always available.")
                             .style("left", (d3.event.pageX) + "px")
                             .style("top", (d3.event.pageY - 28) + "px")
-                            .style("opacity", 1)
                         }
                     )
                     .on("mouseout", function (d) {
@@ -251,26 +260,26 @@ export class VisualizationComponent {
                     .attr("y", LEGEND_TEXT_HEIGHT)
                     .attr("font-weight", 700)
                     .attr("fill", COLOR_QUESTION)
+                    .style("cursor", "pointer")
                     .text("?")
                     .on("mouseover", function (d) {
-                        div.style("height", "65px")
+                        div.style("height", "130px")
                         div.transition()
                             .style("opacity", 1)
                         div.text("Origin distinguishes between entries extracted from Ingamells' Dictionary (")
                             .style("left", (d3.event.pageX) + "px")
                             .style("top", (d3.event.pageY - 28) + "px")
-                            .style("opacity", 1)
                             .append("text")
                                 .style("font-style", "oblique")
                                 .text("DBITI")
                             .append("text")
-                                .text(") and additional entries created in the Explorer database")
+                                .text(") and additional entries created in the Explorer database.")
                                 .style("font-style", "normal")
                         }
                     )
                     .on("mouseout", function (d) {
                         div.transition()
-                            .style("opacity", 0);
+                            .style("opacity", 0)
                         }
                     );
                 break;
@@ -330,7 +339,7 @@ export class VisualizationComponent {
             if (sizeBy === "length") {
                 mySize = Math.max(1, Math.ceil(entry.entryLength * .02)); // about half of dots (count < 50) will be the minimum size
             } else if (sizeBy === "travelTime") {
-                mySize = Math.max(1, Math.ceil(entry.travelTime * 0.000000000054)); // dots with length < 7 months will be minimum size
+                mySize = Math.max(1, Math.ceil(entry.travelTime * 0.00000000003171)); // dots with length < 1 year will be minimum size
             } else {
                 mySize = SIZE_DEFAULT;
             }
@@ -363,16 +372,14 @@ export class VisualizationComponent {
                 .attr('r', zEntry.r)
                 .attr('fill', zEntry.fill)
                 .style("opacity", sizeBy === "none" ? 0.75 : 0.65)
-                // we define "mouseover" handler, here we change tooltip
-                // visibility to "visible" and add appropriate test
+                .style("cursor", "pointer")
 
                 .on("mouseover", function (d) {
                     div.transition()
-                        .style("opacity", .9)
+                        .style("opacity", 1)
                     div.text(zEntry.fullName)
                         .style("left", (d3.event.pageX) + "px")
                         .style("top", (d3.event.pageY - 28) + "px")
-                        .style("opacity", .9)
                     }
                 )
                 .on("mouseout", function (d) {

--- a/public/visualization.component.ts
+++ b/public/visualization.component.ts
@@ -302,7 +302,6 @@ export class VisualizationComponent {
 
         // for visibility purposes, coloring by gender and grouping will also group by gender within each group
         if (colorBy == "gender" && groupBy !== "none") {
-            console.log(entries);
             entries.sort(function(a,b) {
                 let aVal;
                 let bVal;
@@ -405,7 +404,7 @@ export class VisualizationComponent {
                 .attr('cy', zEntry.cy)
                 .attr('r', zEntry.r)
                 .attr('fill', zEntry.fill)
-                .style("opacity", sizeBy === "none" ? 0.75 : 0.65)
+                .style("opacity", sizeBy === "none" ? 1 : colorBy === "none" ? 0.42 : 0.75) // when sizing, dots become more transparent, especially if not coloring
                 .style("cursor", "pointer")
 
                 .on("mouseover", function (d) {

--- a/public/visualization.component.ts
+++ b/public/visualization.component.ts
@@ -151,7 +151,7 @@ export class VisualizationComponent {
                 .text(function (d) { return group.title; });
             y += 15;
 
-            let dotGroup = this.drawDots(entriesInGroup, colorBy, sizeBy, y);
+            let dotGroup = this.drawDots(entriesInGroup, colorBy, sizeBy, groupBy, y);
             y = dotGroup + 50;
         }
         if (colorBy !== "none") {
@@ -290,7 +290,7 @@ export class VisualizationComponent {
      * When given the entries of a group and how the dots should be sized and colored, dots are drawn accordingly. A y variable is stored to
      * properly locate the next group.
      */
-    drawDots(entries, colorBy, sizeBy, y) {
+    drawDots(entries, colorBy, sizeBy, groupBy, y) {
         let x = BUFFER;
 
         let div = d3.select("body").append("div")
@@ -299,6 +299,41 @@ export class VisualizationComponent {
         let width = d3.select("svg")[0][0].clientWidth;
 
         let zEntries = [] as any; // entries sorted by z-index
+
+        // for visibility purposes, coloring by gender and grouping will also group by gender within each group
+        if (colorBy == "gender" && groupBy !== "none") {
+            console.log(entries);
+            entries.sort(function(a,b) {
+                let aVal;
+                let bVal;
+
+                switch (a.gender) {
+                    case "Male":
+                        aVal = -1;
+                        break;
+                    case "Female":
+                        aVal = 0;
+                        break;
+                    default:
+                        aVal = 1;
+                        break;
+                }
+
+                switch (b.gender) {
+                    case "Male":
+                        bVal = -1;
+                        break;
+                    case "Female":
+                        bVal = 0;
+                        break;
+                    default:
+                        bVal = 1;
+                        break;
+                }
+
+                return aVal - bVal;
+            })
+        }
 
         for (let i in entries) {
             let entry = entries[i];

--- a/public/visualization.component.ts
+++ b/public/visualization.component.ts
@@ -165,128 +165,6 @@ export class VisualizationComponent {
     }
 
     /*
-     * When dots are colored, legend is printed at top.
-     */
-    drawLegend(colorBy) {
-        let div = d3.select("body").append("div")
-            .attr("class", "tool_tip")
-            .style("opacity", 0)
-            .style("padding", "12px")
-            .style("max-width", "200px")
-            .style("text-align", "left");
-        switch (colorBy) {
-            case "gender":
-                d3.select('svg').append('circle')
-                    .attr('cx', 5)
-                    .attr('cy', LEGEND_DOT_HEIGHT)
-                    .attr('r', SIZE_DEFAULT)
-                    .attr('fill', COLOR_MALE)
-                    .style("opacity", 0.75)
-                d3.select('svg').append("text")
-                    .attr("x", 12)
-                    .attr("y", LEGEND_TEXT_HEIGHT)
-                    .text("Male");
-                d3.select('svg').append('circle')
-                    .attr('cx', 65)
-                    .attr('cy', LEGEND_DOT_HEIGHT)
-                    .attr('r', SIZE_DEFAULT)
-                    .attr('fill', COLOR_FEMALE)
-                    .style("opacity", 0.75)
-                d3.select('svg').append("text")
-                    .attr("x", 72)
-                    .attr("y", LEGEND_TEXT_HEIGHT)
-                    .text("Female");
-                d3.select('svg').append('circle')
-                    .attr('cx', 145)
-                    .attr('cy', LEGEND_DOT_HEIGHT)
-                    .attr('r', SIZE_DEFAULT)
-                    .attr('fill', COLOR_OTHER)
-                    .style("opacity", 0.75)
-                d3.select('svg').append("text")
-                    .attr("x", 152)
-                    .attr("y", LEGEND_TEXT_HEIGHT)
-                    .text("Unknown");
-                d3.select('svg').append("text")
-                    .attr("x", 222)
-                    .attr("y", LEGEND_TEXT_HEIGHT)
-                    .attr("font-weight", 700)
-                    .attr("fill", COLOR_QUESTION)
-                    .style("cursor", "pointer")
-                    .text("?")
-                    .on("mouseover", function (d) {
-                        div.style("height", "80px")
-                        div.transition()
-                            .style("opacity", 1);
-                        div.text("Gender is a category we attributed and is not always available.")
-                            .style("left", (d3.event.pageX) + "px")
-                            .style("top", (d3.event.pageY - 28) + "px")
-                        }
-                    )
-                    .on("mouseout", function (d) {
-                        div.transition()
-                            .style("opacity", 0);
-                        }
-                    );
-                break;
-            case "new":
-                d3.select('svg').append('circle')
-                    .attr('cx', 5)
-                    .attr('cy', LEGEND_DOT_HEIGHT)
-                    .attr('r', SIZE_DEFAULT)
-                    .attr('fill', COLOR_OLD)
-                    .style("opacity", 0.75)
-                d3.select('svg').append("text")
-                    .attr("x", 12)
-                    .attr("y", LEGEND_TEXT_HEIGHT)            
-                    .style("font-style", "oblique")
-                    .text("DBITI")
-                d3.select('svg').append("text")
-                    .attr("x", 46)
-                    .attr("y", LEGEND_TEXT_HEIGHT)
-                    .text("Entry")
-                    .style("font-style", "normal")
-                d3.select('svg').append('circle')
-                    .attr('cx', 105)
-                    .attr('cy', LEGEND_DOT_HEIGHT)
-                    .attr('r', SIZE_DEFAULT)
-                    .attr('fill', COLOR_NEW)
-                    .style("opacity", 0.75);
-                d3.select('svg').append("text")
-                    .attr("x", 112)
-                    .attr("y", LEGEND_TEXT_HEIGHT)
-                    .text("Explorer Entry");
-                d3.select('svg').append("text")
-                    .attr("x", 222)
-                    .attr("y", LEGEND_TEXT_HEIGHT)
-                    .attr("font-weight", 700)
-                    .attr("fill", COLOR_QUESTION)
-                    .style("cursor", "pointer")
-                    .text("?")
-                    .on("mouseover", function (d) {
-                        div.transition()
-                            .style("opacity", 1)
-                        div.text("Origin distinguishes between entries extracted from Ingamells' Dictionary (")
-                            .style("left", (d3.event.pageX) + "px")
-                            .style("top", (d3.event.pageY - 28) + "px")
-                            .append("text")
-                                .style("font-style", "oblique")
-                                .text("DBITI")
-                            .append("text")
-                                .text(") and additional entries created in the Explorer database.")
-                                .style("font-style", "normal")
-                        }
-                    )
-                    .on("mouseout", function (d) {
-                        div.transition()
-                            .style("opacity", 0)
-                        }
-                    );
-                break;
-            default:
-        }
-    }
-
-    /*
      * When given the entries of a group and how the dots should be sized and colored, dots are drawn accordingly. A y variable is stored to
      * properly locate the next group.
      */
@@ -307,27 +185,15 @@ export class VisualizationComponent {
                 let bVal;
 
                 switch (a.gender) {
-                    case "Male":
-                        aVal = -1;
-                        break;
-                    case "Female":
-                        aVal = 0;
-                        break;
-                    default:
-                        aVal = 1;
-                        break;
+                    case "Male": aVal = -1; break;
+                    case "Female": aVal = 0; break;
+                    default: aVal = 1; // "Unknown"
                 }
 
                 switch (b.gender) {
-                    case "Male":
-                        bVal = -1;
-                        break;
-                    case "Female":
-                        bVal = 0;
-                        break;
-                    default:
-                        bVal = 1;
-                        break;
+                    case "Male": bVal = -1; break;
+                    case "Female": bVal = 0; break;
+                    default: bVal = 1;
                 }
 
                 return aVal - bVal;
@@ -398,7 +264,6 @@ export class VisualizationComponent {
 
         for (let i in zEntries) {
             let zEntry = zEntries[i];
-            // todo: hover boundary of 2px
             d3.select('svg').append('circle')
                 .attr('cx', zEntry.cx)
                 .attr('cy', zEntry.cy)
@@ -408,6 +273,10 @@ export class VisualizationComponent {
                 .style("cursor", "pointer")
 
                 .on("mouseover", function (d) {
+                    d3.select(this)
+                        .attr("stroke", zEntry.fill)
+                        .attr("stroke-opacity", 1)
+                        .attr("stroke-width", 2)
                     div.transition()
                         .style("opacity", 1)
                     div.text(zEntry.fullName)
@@ -416,6 +285,8 @@ export class VisualizationComponent {
                     }
                 )
                 .on("mouseout", function (d) {
+                    d3.select(this)
+                        .attr("stroke-width", 0)
                     div.transition()
                         .style("opacity", 0);
                     }
@@ -582,6 +453,123 @@ export class VisualizationComponent {
             ]
         }
         return mapping[groupBy];
+    }
+
+    /*
+     * When dots are colored, legend is printed at top.
+     */
+    drawLegend(colorBy) {
+        let div = d3.select("body").append("div")
+            .attr("class", "tool_tip")
+            .style("opacity", 0)
+            .style("padding", "12px")
+            .style("max-width", "200px")
+            .style("text-align", "left");
+        switch (colorBy) {
+            case "gender":
+                d3.select('svg').append('circle')
+                    .attr('cx', 5)
+                    .attr('cy', LEGEND_DOT_HEIGHT)
+                    .attr('r', SIZE_DEFAULT)
+                    .attr('fill', COLOR_MALE)
+                d3.select('svg').append("text")
+                    .attr("x", 12)
+                    .attr("y", LEGEND_TEXT_HEIGHT)
+                    .text("Male");
+                d3.select('svg').append('circle')
+                    .attr('cx', 65)
+                    .attr('cy', LEGEND_DOT_HEIGHT)
+                    .attr('r', SIZE_DEFAULT)
+                    .attr('fill', COLOR_FEMALE)
+                d3.select('svg').append("text")
+                    .attr("x", 72)
+                    .attr("y", LEGEND_TEXT_HEIGHT)
+                    .text("Female");
+                d3.select('svg').append('circle')
+                    .attr('cx', 145)
+                    .attr('cy', LEGEND_DOT_HEIGHT)
+                    .attr('r', SIZE_DEFAULT)
+                    .attr('fill', COLOR_OTHER)
+                d3.select('svg').append("text")
+                    .attr("x", 152)
+                    .attr("y", LEGEND_TEXT_HEIGHT)
+                    .text("Unknown");
+                d3.select('svg').append("text")
+                    .attr("x", 222)
+                    .attr("y", LEGEND_TEXT_HEIGHT)
+                    .attr("font-weight", 700)
+                    .attr("fill", COLOR_QUESTION)
+                    .style("cursor", "pointer")
+                    .text("?")
+                    .on("mouseover", function (d) {
+                        div.style("height", "80px")
+                        div.transition()
+                            .style("opacity", 1);
+                        div.text("Gender is a category we attributed and is not always available.")
+                            .style("left", (d3.event.pageX) + "px")
+                            .style("top", (d3.event.pageY - 28) + "px")
+                        }
+                    )
+                    .on("mouseout", function (d) {
+                        div.transition()
+                            .style("opacity", 0);
+                        }
+                    );
+                break;
+            case "new":
+                d3.select('svg').append('circle')
+                    .attr('cx', 5)
+                    .attr('cy', LEGEND_DOT_HEIGHT)
+                    .attr('r', SIZE_DEFAULT)
+                    .attr('fill', COLOR_OLD)
+                d3.select('svg').append("text")
+                    .attr("x", 12)
+                    .attr("y", LEGEND_TEXT_HEIGHT)            
+                    .style("font-style", "oblique")
+                    .text("DBITI")
+                d3.select('svg').append("text")
+                    .attr("x", 46)
+                    .attr("y", LEGEND_TEXT_HEIGHT)
+                    .text("Entry")
+                    .style("font-style", "normal")
+                d3.select('svg').append('circle')
+                    .attr('cx', 105)
+                    .attr('cy', LEGEND_DOT_HEIGHT)
+                    .attr('r', SIZE_DEFAULT)
+                    .attr('fill', COLOR_NEW)
+                d3.select('svg').append("text")
+                    .attr("x", 112)
+                    .attr("y", LEGEND_TEXT_HEIGHT)
+                    .text("Explorer Entry");
+                d3.select('svg').append("text")
+                    .attr("x", 222)
+                    .attr("y", LEGEND_TEXT_HEIGHT)
+                    .attr("font-weight", 700)
+                    .attr("fill", COLOR_QUESTION)
+                    .style("cursor", "pointer")
+                    .text("?")
+                    .on("mouseover", function (d) {
+                        div.transition()
+                            .style("opacity", 1)
+                        div.text("Origin distinguishes between entries extracted from Ingamells' Dictionary (")
+                            .style("left", (d3.event.pageX) + "px")
+                            .style("top", (d3.event.pageY - 28) + "px")
+                            .append("text")
+                                .style("font-style", "oblique")
+                                .text("DBITI")
+                            .append("text")
+                                .text(") and additional entries created in the Explorer database.")
+                                .style("font-style", "normal")
+                        }
+                    )
+                    .on("mouseout", function (d) {
+                        div.transition()
+                            .style("opacity", 0)
+                        }
+                    );
+                break;
+            default:
+        }
     }
 
     clicked(event) {

--- a/public/visualization.component.ts
+++ b/public/visualization.component.ts
@@ -172,7 +172,7 @@ export class VisualizationComponent {
             .attr("class", "tool_tip")
             .style("opacity", 0)
             .style("padding", "12px")
-            .style("width", "200px")
+            .style("max-width", "200px")
             .style("text-align", "left");
         switch (colorBy) {
             case "gender":
@@ -263,7 +263,6 @@ export class VisualizationComponent {
                     .style("cursor", "pointer")
                     .text("?")
                     .on("mouseover", function (d) {
-                        div.style("height", "130px")
                         div.transition()
                             .style("opacity", 1)
                         div.text("Origin distinguishes between entries extracted from Ingamells' Dictionary (")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     "strictNullChecks": false,                /* Disable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+     "noImplicitThis": false,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */


### PR DESCRIPTION
Visualization:
- Question mark drawn on top of dots; pop-ups look more like Explorer page
- Tooltips look better and size according to name length; bug fixed where they would persist after refreshing dots
- Visualization description appearance ready for link to Book
- When grouping and simultaneously coloring by gender, each group is sorted by gender
- Separate "Unknown" group when drawing based on some information on "fake" travelers (entries not representing specific individuals)
- Travel length resized such that travels <1 year are minimum dot size
- "Entry length" changed to "Word count"

Site Appearance:
- Fixed spacing issues on Search and Explore page