### PR TITLE
Load saved lists each time a page is opened

### DIFF
--- a/public/components/entry-list/entry-list.js
+++ b/public/components/entry-list/entry-list.js
@@ -13,6 +13,8 @@ export default ['savedListService', 'entryListContext', '$filter', function(save
     template: require('pug-loader!./entry-list.pug'),
     link: function(scope, element, attributes) {
 
+      savedListService.fetchLists();
+
       // TODO: remove this hack and find a better way to pass around currentUser.
       scope.currentUser = scope.$root.currentUser;
 

--- a/public/entry/entry.js
+++ b/public/entry/entry.js
@@ -14,6 +14,8 @@ export default ['$scope', '$http', '$stateParams', '$sce', '$timeout', '$locatio
   //  expose shared list model to scope
   $scope.sharedListModel = savedListService.sharedListModel
 
+  savedListService.fetchLists();
+
   if ($stateParams.id) {
     
     $scope.id = parseInt($stateParams.id)

--- a/public/lists/list-service.js
+++ b/public/lists/list-service.js
@@ -79,24 +79,27 @@ export default ['$rootScope', '$http', '$window', function($rootScope, $http, $w
   };
 
   //  do initial list download
-  let myListsPromise;
-  if ($rootScope.currentUser) {
-    myListsPromise = $http.post('/api/lists/mylists', {
-      username: $rootScope.currentUser.username
-    })
-    .then(function(res) {
-      if (res.data.error) console.error(res.data.error);
-      else sharedListModel.myLists = res.data.entries;
-      sharedListModel.listsLoading = false;
-    }, function(res) { console.error(res); });
-  } else {
-    // If user is not logged in, do not do an initial list download
-    // and populate sharedListModel with some empty data.
-    myListsPromise = new Promise((resolve, reject) => {
-      sharedListModel.myLists = [];
-      sharedListModel.listsLoading = false;
-      resolve(null);
-    });
+  let fetchLists = async () => {
+    sharedListModel.myLists = [];
+    sharedListModel.listsLoading = true;
+    if ($rootScope.currentUser) {
+      return $http.post('/api/lists/mylists', {
+        username: $rootScope.currentUser.username
+      })
+      .then(function(res) {
+        if (res.data.error) console.error(res.data.error);
+        else sharedListModel.myLists = res.data.entries;
+        sharedListModel.listsLoading = false;
+      }, function(res) { console.error(res); });
+    } else {
+      // If user is not logged in, do not do an initial list download
+      // and populate sharedListModel with some empty data.
+      return new Promise((resolve, reject) => {
+        sharedListModel.myLists = [];
+        sharedListModel.listsLoading = false;
+        resolve(null);
+      });
+    }
   }
 
   //  return service's public fields
@@ -106,7 +109,7 @@ export default ['$rootScope', '$http', '$window', function($rootScope, $http, $w
     deleteList: deleteList,
     addToList: addToList,
     removeFromList: removeFromList,
-    myListsPromise: myListsPromise,
+    fetchLists: fetchLists,
   };
 
 }];

--- a/public/lists/lists.js
+++ b/public/lists/lists.js
@@ -19,6 +19,8 @@ export default ['$scope', '$http', 'savedListService', '$stateParams', '$state',
     //  expose shared list model to scope
     $scope.sharedListModel = savedListService.sharedListModel
 
+    savedListService.fetchLists();
+
     //  functions for list modification
     $scope.newList = function() {
         savedListService.newList(viewModel.newListName, function(list) {
@@ -111,7 +113,7 @@ export default ['$scope', '$http', 'savedListService', '$stateParams', '$state',
 
     //  Selects the list indicated by the URL, if it exists
     
-    if ($stateParams.id) savedListService.myListsPromise.then(function() {
+    if ($stateParams.id) savedListService.fetchLists().then(function() {
 
         var list = savedListService.sharedListModel.myLists.filter(function(list) { return list._id === $stateParams.id })[0]
         if (list) $scope.selectList(list)


### PR DESCRIPTION
Fixes #157. The issue was that previously, the code only fetched the user's lists once (through `myListPromise`) and this same value was cached and used when other pages were opened. This PR fixes that so that the /mylists endpoint is called before any page that uses the lists feature is navigated to.