### PR TITLE
Fix visualization error in which svg is undefined

### DIFF
--- a/public/visualization.component.ts
+++ b/public/visualization.component.ts
@@ -504,8 +504,10 @@ export class VisualizationComponent {
 
         let div = d3.select("body").append("div")
             .attr("class", "tool_tip")
-            .style("opacity", 0)
-        let width = d3.select("svg")[0][0].clientWidth;
+            .style("opacity", 0);
+        const svg = d3.select("svg")[0][0];
+        if (!svg) return;
+        let width = svg.clientWidth;
 
         let zEntries = [] as any; // entries sorted by z-index
 


### PR DESCRIPTION
Sometimes, when switching between the "Explore" and "Visualize" tabs, the whole page errors out because drawDots is called and tries to find the width of the svg element, which is no longer there on the page.

The error that came up is "cannot find property clientWidth of undefined"; this change should fix that.