### PR TITLE
Fixed entry id visibility for viewers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules/
 data/
-*DS_Store
+.DS_Store
 .env
 npm-debug.log
 dist/

--- a/public/entry/entry.pug
+++ b/public/entry/entry.pug
@@ -18,7 +18,7 @@
             span.input-group-btn
               a.btn.btn-default(
                 ng-href="{{ getEntryLink(editingIndex.newIndex) }}",
-                ng-click="handleEntryClick()"x,
+                ng-click="handleEntryClick()",
               ) Go
 
         strong(ng-show="editStatus.mustActivateLatest && editStatus") Activate the Latest revision to edit this entry.
@@ -36,7 +36,7 @@
             ng-class="{ disabled: editStatus.creating }",
             type="button",
             ng-click="editStatus.creating ? null : createEntry()",
-          ) {{ editStatus.creating? 'Creating...' : 'Create Entry' }}
+          ) {{ editStatus.creating ? 'Creating...' : 'Create Entry' }}
 
   .row
     br

--- a/public/entry/entry.pug
+++ b/public/entry/entry.pug
@@ -4,7 +4,7 @@
     .col-lg-12
       revision-status
   
-  .row(ng-show="editStatus")
+  .row
     br
     .col-lg-12
       .edit-status.alert.alert-success
@@ -12,16 +12,16 @@
         .edit-status-entry-index
           span Entry Index: 
           a.alert-link(ng-click="editStatus.editingIndex = true", ng-show="!editStatus.editingIndex") {{ $stateParams.id }}
-          em(ng-show="!editStatus.exists && !editStatus.editingIndex") (Empty)
+          em(ng-show="!editStatus.exists && !editStatus.editingIndex && editStatus") (Empty)
           .input-group.input-group-sm(ng-show="editStatus.editingIndex")
             input.form-control(type="text", ng-model="editingIndex.newIndex")
             span.input-group-btn
               a.btn.btn-default(
                 ng-href="{{ getEntryLink(editingIndex.newIndex) }}",
-                ng-click="handleEntryClick()",
+                ng-click="handleEntryClick()"x,
               ) Go
 
-        strong(ng-show="editStatus.mustActivateLatest") Activate the Latest revision to edit this entry.
+        strong(ng-show="editStatus.mustActivateLatest && editStatus") Activate the Latest revision to edit this entry.
         .btn-group.btn-group-sm(role="group", ng-show="!editStatus.mustActivateLatest && editStatus.exists")
           a.btn.btn-info(
             ng-class="{ disabled: editStatus.duplicating }",
@@ -31,12 +31,12 @@
           
           a.btn.btn-default(type="button" ng-href="#/entries/{{entry.index}}/edit") Edit Entry
 
-        .btn-group.btn-group-sm(role="group", ng-show="!editStatus.mustActivateLatest && !editStatus.exists")
+        .btn-group.btn-group-sm(role="group", ng-show=" editStatus && !editStatus.mustActivateLatest && !editStatus.exists")
           button.btn.btn-sm.btn-default(
             ng-class="{ disabled: editStatus.creating }",
             type="button",
             ng-click="editStatus.creating ? null : createEntry()",
-          ) {{ editStatus.creating ? 'Creating...' : 'Create Entry' }}
+          ) {{ editStatus.creating? 'Creating...' : 'Create Entry' }}
 
   .row
     br


### PR DESCRIPTION
Fixed entry page to display entry id even for viewers without giving them access to editing or duplicating.
Fixed gitignore to include proper DS_Store 
<img width="1228" alt="Screen Shot 2023-04-19 at 12 44 06 PM" src="https://user-images.githubusercontent.com/66948554/233183118-908dc224-2fe4-48c9-bca9-83e9674bd01d.png">
