### PR TITLE
Fixing travel date query error

### DIFF
--- a/__tests__/__snapshots__/query.unit.test.js.snap
+++ b/__tests__/__snapshots__/query.unit.test.js.snap
@@ -696,13 +696,75 @@ Object {
                     Object {
                       "$and": Array [
                         Object {
-                          "travelEndMonth": Object {
-                            "$gte": 1,
+                          "travelEndYear": Object {
+                            "$gt": NaN,
+                          },
+                        },
+                        Object {
+                          "travelStartYear": Object {
+                            "$lt": NaN,
+                          },
+                        },
+                      ],
+                    },
+                    Object {
+                      "$and": Array [
+                        Object {
+                          "travelEndYear": Object {
+                            "$eq": NaN,
+                          },
+                        },
+                        Object {
+                          "travelStartYear": Object {
+                            "$eq": NaN,
                           },
                         },
                         Object {
                           "travelStartMonth": Object {
                             "$lte": 1,
+                          },
+                        },
+                        Object {
+                          "travelEndMonth": Object {
+                            "$gte": 1,
+                          },
+                        },
+                      ],
+                    },
+                    Object {
+                      "$and": Array [
+                        Object {
+                          "travelEndYear": Object {
+                            "$gt": NaN,
+                          },
+                        },
+                        Object {
+                          "travelStartYear": Object {
+                            "$eq": NaN,
+                          },
+                        },
+                        Object {
+                          "travelStartMonth": Object {
+                            "$lte": 1,
+                          },
+                        },
+                      ],
+                    },
+                    Object {
+                      "$and": Array [
+                        Object {
+                          "travelStartYear": Object {
+                            "$lt": NaN,
+                          },
+                        },
+                        Object {
+                          "travelEndYear": Object {
+                            "$eq": NaN,
+                          },
+                        },
+                        Object {
+                          "travelEndMonth": Object {
+                            "$gte": 1,
                           },
                         },
                       ],
@@ -753,13 +815,75 @@ Object {
                     Object {
                       "$and": Array [
                         Object {
-                          "travelEndMonth": Object {
-                            "$gte": 1,
+                          "travelEndYear": Object {
+                            "$gt": NaN,
+                          },
+                        },
+                        Object {
+                          "travelStartYear": Object {
+                            "$lt": NaN,
+                          },
+                        },
+                      ],
+                    },
+                    Object {
+                      "$and": Array [
+                        Object {
+                          "travelEndYear": Object {
+                            "$eq": NaN,
+                          },
+                        },
+                        Object {
+                          "travelStartYear": Object {
+                            "$eq": NaN,
                           },
                         },
                         Object {
                           "travelStartMonth": Object {
                             "$lte": 1,
+                          },
+                        },
+                        Object {
+                          "travelEndMonth": Object {
+                            "$gte": 1,
+                          },
+                        },
+                      ],
+                    },
+                    Object {
+                      "$and": Array [
+                        Object {
+                          "travelEndYear": Object {
+                            "$gt": NaN,
+                          },
+                        },
+                        Object {
+                          "travelStartYear": Object {
+                            "$eq": NaN,
+                          },
+                        },
+                        Object {
+                          "travelStartMonth": Object {
+                            "$lte": 1,
+                          },
+                        },
+                      ],
+                    },
+                    Object {
+                      "$and": Array [
+                        Object {
+                          "travelStartYear": Object {
+                            "$lt": NaN,
+                          },
+                        },
+                        Object {
+                          "travelEndYear": Object {
+                            "$eq": NaN,
+                          },
+                        },
+                        Object {
+                          "travelEndMonth": Object {
+                            "$gte": 1,
                           },
                         },
                       ],
@@ -857,13 +981,75 @@ Object {
                     Object {
                       "$and": Array [
                         Object {
-                          "travelEndMonth": Object {
-                            "$gte": 5,
+                          "travelEndYear": Object {
+                            "$gt": 1700,
+                          },
+                        },
+                        Object {
+                          "travelStartYear": Object {
+                            "$lt": 1700,
+                          },
+                        },
+                      ],
+                    },
+                    Object {
+                      "$and": Array [
+                        Object {
+                          "travelEndYear": Object {
+                            "$eq": 1700,
+                          },
+                        },
+                        Object {
+                          "travelStartYear": Object {
+                            "$eq": 1700,
                           },
                         },
                         Object {
                           "travelStartMonth": Object {
                             "$lte": 5,
+                          },
+                        },
+                        Object {
+                          "travelEndMonth": Object {
+                            "$gte": 5,
+                          },
+                        },
+                      ],
+                    },
+                    Object {
+                      "$and": Array [
+                        Object {
+                          "travelEndYear": Object {
+                            "$gt": 1700,
+                          },
+                        },
+                        Object {
+                          "travelStartYear": Object {
+                            "$eq": 1700,
+                          },
+                        },
+                        Object {
+                          "travelStartMonth": Object {
+                            "$lte": 5,
+                          },
+                        },
+                      ],
+                    },
+                    Object {
+                      "$and": Array [
+                        Object {
+                          "travelStartYear": Object {
+                            "$lt": 1700,
+                          },
+                        },
+                        Object {
+                          "travelEndYear": Object {
+                            "$eq": 1700,
+                          },
+                        },
+                        Object {
+                          "travelEndMonth": Object {
+                            "$gte": 5,
                           },
                         },
                       ],

--- a/query.js
+++ b/query.js
@@ -293,12 +293,35 @@ var searchMap = {
                     { travelEndMonth: { $exists: false } },
                     { travelStartMonth: { $eq: 0 } },
                     { travelEndMonth: { $eq: 0 } },
+                    { 
+                        $and: [
+                            { travelEndYear: { $gt: startYear } },
+                            { travelStartYear: { $lt: startYear } }
+                        ],
+                    },
+                    { 
+                        $and: [
+                            { travelEndYear: { $eq: startYear } },
+                            { travelStartYear: { $eq: startYear } },
+                            { travelStartMonth: { $lte: startMonth} },
+                            { travelEndMonth: { $gte: startMonth } }
+                        ],
+                    },
+                    { 
+                        $and: [
+                            { travelEndYear: { $gt: startYear } },
+                            { travelStartYear: { $eq: startYear} },
+                            { travelStartMonth: { $lte: startMonth } }
+                        ],
+                    },
                     {
                         $and: [
-                            { travelEndMonth: { $gte: startMonth } },
-                            { travelStartMonth: { $lte: startMonth } }
-                        ]
+                            { travelStartYear: { $lt: startYear } },
+                            { travelEndYear: { $eq: startYear} },
+                            { travelEndMonth: { $gte: startMonth } }
+                        ],
                     }
+
                 ]
             },
             rangeOfYears: {


### PR DESCRIPTION
Fixing the query matching statement that was causing this error:

"if one does a search in the Explorer for travelers who were in Rome in June 1752 one gets 51 results which all make sense (I have gone through them all individually) but one does not get entry 897, for James Caulfield 4th viscount Charlemont (https://grandtourexplorer.wc.reclaim.cloud/#/entries/897 ), whom I know was in Rome then, but most importantly it is someone whose data in the Explorer show him to be in Rome at that time: why is he missing? "

- Original query logic checked if travel end month was gte to query month and if travel start month was lte to query month but this did not take into account the corresponding year constraints at the same time. 
- Edited query to separately handle when start month and end month are in the same year as the query month and when start and end year were in the same year. 


<img width="1440" alt="Screen Shot 2023-05-04 at 10 19 07 PM" src="https://user-images.githubusercontent.com/66948554/236383565-3de364f2-84a1-469c-b57c-2ca0fd031ac6.png">
